### PR TITLE
fix: use stable vertexai.agent_engines.AdkApp instead of preview

### DIFF
--- a/deploy_agent_to_agentengine.py
+++ b/deploy_agent_to_agentengine.py
@@ -5,7 +5,7 @@ import json
 import vertexai
 from vertexai import types
 from vertexai import agent_engines
-from vertexai.preview.reasoning_engines import AdkApp
+from vertexai.agent_engines import AdkApp
 
 from google.adk.agents import SequentialAgent
 


### PR DESCRIPTION
## Summary

- Replaces `from vertexai.preview.reasoning_engines import AdkApp` with `from vertexai.agent_engines import AdkApp`

## Problem

The preview `AdkApp` caused a `401 Unauthorized` error when exporting OpenTelemetry spans to `telemetry.googleapis.com`. Investigation showed the stable version includes mTLS support and improved credential handling for the telemetry endpoint that the preview version lacks.

The 401 was non-retryable, causing all trace exports to silently fail despite `enable_tracing=True` and `GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY=true` being set. After switching to the stable import, spans are successfully exported to Cloud Trace and visible with full labels (agent names, token counts, invocation IDs, etc.).

## Test plan

- [x] Deployed agent to Agent Engine with stable import
- [x] Verified no `Failed to export span batch code: 401` errors in Stackdriver logs
- [x] Queried Cloud Trace and confirmed spans are present with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)